### PR TITLE
Добавлена поддержка web клиента grpc для использования в wasm.

### DIFF
--- a/Tinkoff.InvestApi/InvestApiClientExtensions.cs
+++ b/Tinkoff.InvestApi/InvestApiClientExtensions.cs
@@ -1,5 +1,6 @@
 ﻿using Grpc.Core;
 using Grpc.Net.Client.Configuration;
+using Grpc.Net.Client.Web;
 using Tinkoff.InvestApi;
 
 namespace Microsoft.Extensions.DependencyInjection;
@@ -9,13 +10,11 @@ public static class InvestApiClientExtensions
     private const string DefaultName = "";
 
     public static IServiceCollection AddInvestApiClient(this IServiceCollection services,
-        Action<IServiceProvider, InvestApiSettings> configureSettings)
-    {
-        return AddInvestApiClient(services, DefaultName, configureSettings);
-    }
+        Action<IServiceProvider, InvestApiSettings> configureSettings, bool isWebClient = false) =>
+            AddInvestApiClient(services, DefaultName, configureSettings, isWebClient);
 
     public static IServiceCollection AddInvestApiClient(this IServiceCollection services, string name,
-        Action<IServiceProvider, InvestApiSettings> configureSettings)
+        Action<IServiceProvider, InvestApiSettings> configureSettings, bool isWebClient = false)
     {
         services.AddGrpcClient<InvestApiClient>(name,
                 (serviceProvider, options) =>
@@ -28,6 +27,9 @@ public static class InvestApiClientExtensions
                 })
             .ConfigureChannel((serviceProvider, options) =>
             {
+                if (isWebClient)
+                    options.HttpHandler = new GrpcWebHandler(new HttpClientHandler());
+
                 options.MaxReceiveMessageSize = null;
                 var settings = new InvestApiSettings();
                 configureSettings(serviceProvider, settings);

--- a/Tinkoff.InvestApi/Tinkoff.InvestApi.csproj
+++ b/Tinkoff.InvestApi/Tinkoff.InvestApi.csproj
@@ -20,6 +20,7 @@
         <PackageReference Include="Google.Api.CommonProtos" Version="2.13.0" />
         <PackageReference Include="Google.Protobuf" Version="3.25.1" />
         <PackageReference Include="Grpc.Net.Client" Version="2.59.0" />
+		<PackageReference Include="Grpc.Net.Client.Web" Version="2.59.0" />
         <PackageReference Include="Grpc.Net.ClientFactory" Version="2.59.0" />
         <PackageReference Include="Grpc.Tools" Version="2.59.0">
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>


### PR DESCRIPTION
В метод AddInvestApiClient добавлен параметр isWebClient, позволяющий использовать API в wasm приложениях. Протестировано на Blazor.