### PR TITLE
Update create-pull-request action to v6.0.1

### DIFF
--- a/.github/workflows/update-contracts.yml
+++ b/.github/workflows/update-contracts.yml
@@ -102,7 +102,7 @@ jobs:
           sed -i "s/<PackageVersion>.*<\/PackageVersion>/<PackageVersion>${{ steps.bump_release_version.outputs.next-version }}<\/PackageVersion>/" ./Tinkoff.InvestApi/Tinkoff.InvestApi.csproj
 
       - name: Create pull request
-        uses: peter-evans/create-pull-request@v5
+        uses: peter-evans/create-pull-request@v6.0.1
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           commit-message: Update contracts to ${{ needs.get-latest-tag.outputs.tag_name }}


### PR DESCRIPTION
The pull request creation step in the update-contracts workflow has been updated. The action used for this, `peter-evans/create-pull-request`, has been moved from version 5 to version 6.0.1.

https://github.com/peter-evans/create-pull-request/issues/2790